### PR TITLE
handling of grpc generated file dependency management

### DIFF
--- a/src/generated/CMakeLists.txt
+++ b/src/generated/CMakeLists.txt
@@ -27,7 +27,8 @@ foreach(elem ${PROTO_FILES})
     list(APPEND GRPC_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${file_no_ext}.grpc.pb.cc)
 endforeach()
 
-# Add a custom target to generate the C++ headers from the .proto files using
+# Add a custom command to generate the C++ headers and sources from the .proto files
+# This command only runs when the proto files are modified (incremental builds)
 add_custom_command(
     OUTPUT ${PROTO_HEADERS} ${GRPC_HEADERS} ${GRPC_MOCK_HEADERS} ${PROTO_SRC} ${GRPC_SRC}
     COMMAND protobuf::protoc
@@ -39,6 +40,13 @@ add_custom_command(
     DEPENDS ${PROTO_FILES_DEPEND}
     COMMENT "Generating C++ stubs from protobuf files"
 )
+
+# Create a custom target that depends on all generated files
+# This ensures the generation happens before any target that depends on GrpcGenerated
+add_custom_target(GenerateGrpcFiles
+    DEPENDS ${PROTO_HEADERS} ${GRPC_HEADERS} ${GRPC_MOCK_HEADERS} ${PROTO_SRC} ${GRPC_SRC}
+)
+
 install(FILES ${PROTO_FILES_DEPEND}
     DESTINATION proto
 )
@@ -46,6 +54,10 @@ install(FILES ${PROTO_HEADERS} ${GRPC_HEADERS} ${GRPC_MOCK_HEADERS}
         DESTINATION include
 )
 
-add_library(GrpcGenerated OBJECT ${PROTO_HEADERS} ${PROTO_SRC} ${GRPC_SRC})
+# Create the GrpcGenerated library using the generated sources
+add_library(GrpcGenerated OBJECT ${PROTO_SRC} ${GRPC_SRC})
+
+# Ensure the library depends on the generation target
+add_dependencies(GrpcGenerated GenerateGrpcFiles)
 
 target_link_libraries(GrpcGenerated PRIVATE protobuf::libprotobuf gRPC::grpc++)


### PR DESCRIPTION
## Summary

  This PR improves the gRPC generated file dependency management in the CMake build system by properly separating the generation step from the library build, ensuring correct build ordering and incremental builds.

Fixes #17 

## Changes

### Build System Fix

  - Separated gRPC generation into explicit target: Created GenerateGrpcFiles custom target that depends on all generated protobuf/gRPC files
  - Added explicit dependency chain: The GrpcGenerated library now explicitly depends on GenerateGrpcFiles target
  - Improved incremental builds: Custom command only regenerates files when proto files are modified
  - Cleaner library definition: Removed headers from add_library() call since they're outputs, not sources

### Technical Details

  The previous implementation combined the generation and compilation steps, which could cause race conditions in parallel builds. This change ensures:
  1. Proto files are generated first via GenerateGrpcFiles target
  2. Generated files are available before GrpcGenerated library compilation starts
  3. Parallel builds (make -j) work reliably
  4. Incremental builds skip regeneration when proto files haven't changed

### Test Plan

  - Library builds successfully with make
  - Parallel builds work correctly with make -j
  - Incremental builds skip regeneration appropriately
  - CI passes with updated workflow