### PR TITLE
Add GitHub Issue and Pull Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,66 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior in Philote-Cpp
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+
+<!-- Provide a clear and concise description of the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+4.
+
+## Expected Behavior
+
+<!-- Describe what you expected to happen -->
+
+## Actual Behavior
+
+<!-- Describe what actually happened -->
+
+## Error Messages
+
+<!-- If applicable, paste any error messages or stack traces -->
+
+```
+[Paste error messages here]
+```
+
+## Environment
+
+**Platform:**
+- OS: [e.g., Ubuntu 24.04, macOS 14]
+- Compiler: [e.g., gcc-13, clang-18]
+- CMake version: [e.g., 3.28.1]
+- Philote-Cpp version/commit: [e.g., v0.4.0 or commit hash]
+- gRPC version: [e.g., 1.60.0]
+
+**Build Configuration:**
+- Build type: [e.g., Release, Debug]
+- CMake options: [e.g., -DENABLE_COVERAGE=ON]
+
+## Code Sample
+
+<!-- If applicable, provide a minimal code example that reproduces the issue -->
+
+```cpp
+// Paste your code here
+```
+
+## Additional Context
+
+<!-- Add any other context about the problem here -->
+- Does this issue occur consistently or intermittently?
+- Did this work in a previous version?
+- Are there any workarounds?
+
+## Possible Solution
+
+<!-- Optional: If you have suggestions on how to fix this, please describe them -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/MDO-Standards/Philote-Cpp/discussions
+    about: For general questions, discussions, and community support
+  - name: Contributing Guide
+    url: https://github.com/MDO-Standards/Philote-Cpp/blob/main/CONTRIBUTING.md
+    about: Learn how to contribute to Philote-Cpp
+  - name: Documentation
+    url: https://github.com/MDO-Standards/Philote-Cpp/tree/main/docs
+    about: View the project documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,67 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for Philote-Cpp
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+
+<!-- Provide a clear and concise description of the feature you'd like to see -->
+
+## Problem or Use Case
+
+<!-- Describe the problem this feature would solve or the use case it would enable -->
+
+**Is your feature request related to a problem?**
+<!-- e.g., "I'm always frustrated when..." or "It's difficult to..." -->
+
+## Proposed Solution
+
+<!-- Describe how you envision this feature working -->
+
+## Alternatives Considered
+
+<!-- Have you considered any alternative solutions or features? -->
+
+## Implementation Ideas
+
+<!-- Optional: If you have ideas about how to implement this, share them here -->
+
+## Benefits
+
+<!-- What benefits would this feature provide? -->
+
+-
+-
+-
+
+## Potential Drawbacks
+
+<!-- Are there any potential downsides or trade-offs? -->
+
+## Compatibility
+
+<!-- Would this be a breaking change? How would it affect existing code? -->
+
+- [ ] This is a breaking change
+- [ ] This is backward compatible
+- [ ] This requires changes to the Philote standard
+
+## Additional Context
+
+<!-- Add any other context, examples, or mockups about the feature request here -->
+
+## Related Issues/PRs
+
+<!-- Link to related issues or pull requests if any exist -->
+
+## Willingness to Contribute
+
+<!-- Would you be willing to help implement this feature? -->
+
+- [ ] I am willing to submit a PR for this feature
+- [ ] I can help with testing
+- [ ] I can help with documentation
+- [ ] I'm just suggesting the idea

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,34 @@
+---
+name: General Issue
+about: For questions, documentation issues, or anything that doesn't fit other categories
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Issue Type
+
+<!-- Mark the most relevant option with an "x" -->
+
+- [ ] Question
+- [ ] Documentation issue
+- [ ] Build/Installation problem
+- [ ] Platform support inquiry
+- [ ] Other
+
+## Description
+
+<!-- Provide a clear description of your issue or question -->
+
+## Context
+
+<!-- Provide any relevant context that would help understand your issue -->
+
+**Environment (if applicable):**
+- OS:
+- Compiler:
+- Philote-Cpp version:
+
+## Additional Information
+
+<!-- Add any other information that might be helpful -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,69 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+<!-- Mark the relevant option with an "x" -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] Performance improvement
+- [ ] Test additions/improvements
+
+## Related Issues
+
+<!-- Link to related issues using "Fixes #123" or "Relates to #456" -->
+
+Fixes #
+
+## Changes Made
+
+<!-- Provide a detailed list of changes -->
+
+-
+-
+-
+
+## Testing
+
+<!-- Describe the tests you ran and how to reproduce them -->
+
+- [ ] All existing tests pass (`ctest`)
+- [ ] Added new tests for new functionality
+- [ ] Tested on supported platforms/compilers (if applicable)
+
+**Test Results:**
+```
+<!-- Paste relevant test output here -->
+```
+
+## Documentation
+
+- [ ] Updated relevant documentation in `docs/`
+- [ ] Added/updated code comments and docstrings
+- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
+- [ ] Updated README if needed
+
+## Code Quality
+
+- [ ] Code follows the [coding style guide](docs/coding_style.md)
+- [ ] No new compiler warnings introduced
+- [ ] Code is formatted with clang-format (`.clang-format`)
+- [ ] All CI checks pass
+
+## Additional Context
+
+<!-- Add any other context, screenshots, or information about the PR here -->
+
+## Checklist
+
+- [ ] My code follows the contribution guidelines in [CONTRIBUTING.md](CONTRIBUTING.md)
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
# Add GitHub Issue and Pull Request Templates

## Title
Add GitHub issue and pull request templates

## Base Branch
`develop`

## Head Branch
`feature/templates`

## Summary
This PR adds standardized GitHub templates for issues and pull requests to improve contribution workflow and issue tracking.

## Changes Made
- Added bug report template with structured format for reporting bugs
- Added feature request template for proposing new features
- Added general issue template for questions and other topics
- Added issue template configuration with links to discussions and documentation
- Added comprehensive pull request template with checklist and guidelines

## Files Added
- `.github/ISSUE_TEMPLATE/bug_report.md` (66 lines)
- `.github/ISSUE_TEMPLATE/feature_request.md` (67 lines)
- `.github/ISSUE_TEMPLATE/general.md` (34 lines)
- `.github/ISSUE_TEMPLATE/config.yml` (11 lines)
- `.github/PULL_REQUEST_TEMPLATE.md` (69 lines)

**Total:** 5 files changed, 247 insertions(+)

## Benefits
- Provides consistent structure for issue reporting
- Helps contributors provide all necessary information
- Guides users through the contribution process
- Links to relevant resources (discussions, documentation, contributing guide)
- Improves maintainability and issue triage

## Test Plan
- [ ] Verify templates appear when creating new issues on GitHub
- [ ] Verify PR template appears when creating new pull requests
- [ ] Verify config links work correctly
- [ ] Test each template type (bug report, feature request, general)

